### PR TITLE
Compatible with iOS 15

### DIFF
--- a/JamLog.podspec
+++ b/JamLog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'JamLog'
-  s.version          = '1.1.1'
+  s.version          = '1.1.2'
   s.summary          = 'Log to Jam from iOS.'
 
   s.description      = <<-DESC
@@ -12,7 +12,7 @@ This framework lets you send log events to Jam for iOS so that they can be assoc
   s.author           = { 'Matt Comi' => 'matt@jam.dev' }
   s.source           = { :git => 'https://github.com/jamdotdev/jam-ios-log.git', :tag => "v#{s.version}" }
   s.swift_version = '5.9'
-  s.ios.deployment_target = '17.0'
+  s.ios.deployment_target = '15.0'
 
   s.source_files = 'Sources/JamLog/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "JamLog",
   platforms: [
-    .iOS(.v17),
+    .iOS(.v15),
   ],
   products: [
     .library(

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This framework lets you send log events to [Jam for iOS](https://apps.apple.com/
 
 ## Supported Platforms
 
-- iOS 17.0+
+- iOS 15.0+
 
 ## Quick Start
 


### PR DESCRIPTION
Adds a pre-iOS 17 codepath:

- `NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)`
- `UIScreen.isCaptured`

It is not possible to use `NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)` and `traitCollection.sceneCaptureState == .active` together on iOS 17; the notification fires before the trait collection is updated.

