### PR TITLE
Log trace is optional

### DIFF
--- a/JamLog.podspec
+++ b/JamLog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'JamLog'
-  s.version          = '1.1.2'
+  s.version          = '1.1.3'
   s.summary          = 'Log to Jam from iOS.'
 
   s.description      = <<-DESC

--- a/Sources/JamLog/JamLog.swift
+++ b/Sources/JamLog/JamLog.swift
@@ -30,16 +30,15 @@ public enum JamLog {
   public static func log(
     _ message: String,
     level: LogMessage.Level,
+    includesTrace: Bool = true,
     file: String = #fileID,
     function: String = #function,
     line: UInt = #line
   ) {
     Task.detached {
-      let logMessage = LogMessage(
-        level: level,
-        message: message,
-        trace: .init(file: file, function: function, line: line)
-      )
+      let trace: LogMessage.Trace? = includesTrace ? .init(file: file, function: function, line: line) : nil
+
+      let logMessage = LogMessage(level: level, message: message, trace: trace)
 
       await Logger.shared.log(logMessage)
     }

--- a/Sources/JamLog/LogMessage.swift
+++ b/Sources/JamLog/LogMessage.swift
@@ -21,9 +21,9 @@ public struct LogMessage: Codable, Sendable {
 
   public let level: Level
   public let message: String
-  public let trace: Trace
+  public let trace: Trace?
 
-  public init(level: Level, message: String, trace: Trace) {
+  public init(level: Level, message: String, trace: Trace?) {
     self.level = level
     self.message = message
     self.trace = trace


### PR DESCRIPTION
Adds an optional `includesTrace` to `JamLog.log`, e.g.

```swift
JamLog.log("Hello", level: .debug, includesTrace: false)
```